### PR TITLE
Refactor checklist fixer to avoid regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv/
+.venv/

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -1,6 +1,10 @@
 # AIM2 Detailed Tiny-Task Checklists (TDD-first)
 _Each ticket begins with tests and ends by re-running tests. IDs are TicketID-TaskNN._
 
+## DOC-001 — Checklist format utility
+- [x] DOC-001-01: Replace regex usage in `docs/fix_checklist_format.py` with custom pattern matching.
+- [x] DOC-001-02: Add unit tests for `fix_checkbox_format`.
+
 ## INF-001 — Repo skeleton & packaging
 - [ ] INF-001-01: Author unit test plan for **Repo skeleton & packaging** (acceptance criteria → concrete tests).
 - [ ] INF-001-02: Write failing unit tests covering happy path, edge cases, and error handling.

--- a/docs/fix_checklist_format.py
+++ b/docs/fix_checklist_format.py
@@ -1,4 +1,22 @@
-import re
+def _normalize_checkbox(line):
+    """Return line with any leading checkbox marker normalized to '- [ ]'."""
+    prefix_spaces = len(line) - len(line.lstrip())
+    leading = line[:prefix_spaces]
+    stripped = line[prefix_spaces:]
+    if stripped.startswith("- [ ]"):
+        return line
+    marker = ""
+    if stripped.startswith("*") or stripped.startswith("-"):
+        marker = stripped[1:]
+    else:
+        return line
+    trimmed = marker.lstrip()
+    cleaned = trimmed.replace("\\[", "[").replace("\\]", "]")
+    if cleaned.startswith("[ ]"):
+        rest = cleaned[3:]
+        return f"{leading}- [ ]{rest}"
+    return line
+
 
 def fix_checkbox_format(input_file, output_file):
     """
@@ -11,12 +29,7 @@ def fix_checkbox_format(input_file, output_file):
 
         corrected_lines = []
         for line in lines:
-            # Replace incorrect checkbox formats with the correct format
-            corrected_line = re.sub(
-                r'^\s*[\*\-]\s*\[ \]|^\s*\*\s*\[ \]|^\s*\*\s*\\\[ \\\]',
-                '- [ ]',
-                line
-            )
+            corrected_line = _normalize_checkbox(line)
             corrected_lines.append(corrected_line)
 
         with open(output_file, 'w') as outfile:

--- a/tests/test_fix_checkbox_format.py
+++ b/tests/test_fix_checkbox_format.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[1] / "docs"
+if str(module_path) not in sys.path:
+    sys.path.append(str(module_path))
+
+import fix_checklist_format
+
+
+def test_fix_checkbox_format(tmp_path):
+    input_file = tmp_path / "input.md"
+    output_file = tmp_path / "output.md"
+    lines = ["* [ ] one\n", "- [ ] two\n", "* \\[ \\] three\n", "no box\n"]
+    with open(input_file, "w") as handle:
+        for item in lines:
+            handle.write(item)
+    fix_checklist_format.fix_checkbox_format(str(input_file), str(output_file))
+    with open(output_file, "r") as handle:
+        result_lines = handle.readlines()
+    assert result_lines[0].startswith("- [ ]")
+    assert result_lines[1].startswith("- [ ]")
+    assert result_lines[2].startswith("- [ ]")
+    assert result_lines[3] == "no box\n"


### PR DESCRIPTION
## Summary
- replace regex usage in docs/fix_checklist_format.py with custom string-based pattern matcher
- add tests for checklist fixer utility
- note new DOC-001 ticket in checklist

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68913352cd908321ac7372de32c8abaa